### PR TITLE
Add sentiment analysis loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # SentimentAnalysis
+
+
+This repository provides a simple Python program for loading a pre-trained
+sentiment analysis model using the Hugging Face `transformers` library.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the example script to load the model and analyze sample sentences:
+
+```bash
+python sentiment_loader.py
+```
+
+The script will print out the predicted sentiment labels and their scores for
+some example sentences. You can modify the examples in `sentiment_loader.py` or
+use the returned pipeline object to analyze your own text.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+transformers
+torch

--- a/sentiment_loader.py
+++ b/sentiment_loader.py
@@ -1,0 +1,21 @@
+from transformers import pipeline
+
+
+def load_sentiment_model(model_name="distilbert-base-uncased-finetuned-sst-2-english"):
+    """Load and return a sentiment analysis pipeline."""
+    return pipeline("sentiment-analysis", model=model_name)
+
+
+def main():
+    model = load_sentiment_model()
+    examples = [
+        "I love this product!",
+        "This is the worst experience I've ever had."
+    ]
+    results = model(examples)
+    for text, result in zip(examples, results):
+        print(f"{text} -> {result['label']} (score: {result['score']:.4f})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `sentiment_loader.py` that loads a pretrained sentiment model
- document setup and usage in README
- add `requirements.txt` with dependencies

## Testing
- `python -m py_compile sentiment_loader.py`
- `pip install -r requirements.txt` *(fails: large downloads cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6878d491e604832dba2f5268571bc07d